### PR TITLE
Normalize to speed up distance calculation

### DIFF
--- a/bruteforce_test.go
+++ b/bruteforce_test.go
@@ -13,7 +13,7 @@ import (
 
 /*
 cpu: 13th Gen Intel(R) Core(TM) i7-13700K
-BenchmarkIndex/search-24         	    4029	    298055 ns/op	     272 B/op	       3 allocs/op
+BenchmarkIndex/search-24         	    5366	    217116 ns/op	     272 B/op	       3 allocs/op
 */
 func BenchmarkIndex(b *testing.B) {
 	data, err := loadDataset()

--- a/internal/cosine/cosine_apple.c
+++ b/internal/cosine/cosine_apple.c
@@ -27,3 +27,14 @@ void f32_cosine_distance(const float *x, const float *y, double *result, const u
     double cosine_similarity = (double)sum_xy / (double)denominator;
     *result = cosine_similarity;
 }
+
+void f32_dot_product(const float *x, const float *y, double *result, const uint64_t size) {
+    float sum = 0.0f;
+
+    #pragma clang loop vectorize(enable) interleave(enable)
+    for (uint64_t i = 0; i < size; i++) {
+        sum += x[i] * y[i];
+    }
+
+    *result = (double)sum;
+}

--- a/internal/cosine/cosine_avx.c
+++ b/internal/cosine/cosine_avx.c
@@ -13,8 +13,8 @@ void f32_cosine_distance(const float *x, const float *y, double *result, const u
     #pragma clang loop vectorize(enable) interleave_count(2)
     for (uint64_t i = 0; i < size; i++) {
         sum_xy += x[i] * y[i];    // Sum of x * y
-        sum_xx += x[i] * x[i];     // Sum of x * x
-        sum_yy += y[i] * y[i];     // Sum of y * y
+        sum_xx += x[i] * x[i];    // Sum of x * x
+        sum_yy += y[i] * y[i];    // Sum of y * y
     }
 
     // Calculate the final result
@@ -26,4 +26,15 @@ void f32_cosine_distance(const float *x, const float *y, double *result, const u
 
     double cosine_similarity = (double)sum_xy / (double)denominator;
     *result = cosine_similarity;
+}
+
+void f32_dot_product(const float *x, const float *y, double *result, const uint64_t size) {
+    float sum = 0.0f;
+
+    #pragma clang loop vectorize(enable) interleave(enable)
+    for (uint64_t i = 0; i < size; i++) {
+        sum += x[i] * y[i];
+    }
+
+    *result = (double)sum;
 }

--- a/internal/cosine/cosine_neon.c
+++ b/internal/cosine/cosine_neon.c
@@ -27,3 +27,14 @@ void f32_cosine_distance(const float *x, const float *y, double *result, const u
     double cosine_similarity = (double)sum_xy / (double)denominator;
     *result = cosine_similarity;
 }
+
+void f32_dot_product(const float *x, const float *y, double *result, const uint64_t size) {
+    float sum = 0.0f;
+
+    #pragma clang loop vectorize(enable) interleave(enable)
+    for (uint64_t i = 0; i < size; i++) {
+        sum += x[i] * y[i];
+    }
+
+    *result = (double)sum;
+}

--- a/internal/cosine/simd/cosine_apple.go
+++ b/internal/cosine/simd/cosine_apple.go
@@ -7,3 +7,6 @@ import "unsafe"
 
 //go:noescape,nosplit
 func f32_cosine_distance(x unsafe.Pointer, y unsafe.Pointer, result unsafe.Pointer, size uint64)
+
+//go:noescape,nosplit
+func f32_dot_product(x unsafe.Pointer, y unsafe.Pointer, result unsafe.Pointer, size uint64)

--- a/internal/cosine/simd/cosine_apple.s
+++ b/internal/cosine/simd/cosine_apple.s
@@ -114,3 +114,65 @@ BB0_11:
 	WORD $0xfd000040 // str	d0, [x2]
 	WORD $0xa8c17bfd // ldp	x29, x30, [sp], #16             ; 16-byte Folded Reload
 	WORD $0xd65f03c0 // ret
+
+TEXT ·f32_dot_product(SB), $0-32
+	MOVD x+0(FP), R0
+	MOVD y+8(FP), R1
+	MOVD result+16(FP), R2
+	MOVD size+24(FP), R3
+	WORD $0xa9bf7bfd       // stp	x29, x30, [sp, #-16]!           ; 16-byte Folded Spill
+	WORD $0x910003fd       // mov	x29, sp
+	WORD $0xb40000c3       // cbz	x3, LBB1_3
+	WORD $0xf100207f       // cmp	x3, #8
+	WORD $0x54000102       // b.hs	LBB1_4
+	WORD $0xd2800008       // mov	x8, #0
+	WORD $0x2f00e400       // movi	d0, #0000000000000000
+	WORD $0x14000018       // b	LBB1_7
+
+BB1_3:
+	WORD $0x2f00e400 // movi	d0, #0000000000000000
+	WORD $0xfd000040 // str	d0, [x2]
+	WORD $0xa8c17bfd // ldp	x29, x30, [sp], #16             ; 16-byte Folded Reload
+	WORD $0xd65f03c0 // ret
+
+BB1_4:
+	WORD $0x927df068 // and	x8, x3, #0xfffffffffffffff8
+	WORD $0x91004009 // add	x9, x0, #16
+	WORD $0x9100402a // add	x10, x1, #16
+	WORD $0x6f00e400 // movi.2d	v0, #0000000000000000
+	WORD $0xaa0803eb // mov	x11, x8
+	WORD $0x6f00e401 // movi.2d	v1, #0000000000000000
+
+BB1_5:
+	WORD $0xad7f8d22 // ldp	q2, q3, [x9, #-16]
+	WORD $0xad7f9544 // ldp	q4, q5, [x10, #-16]
+	WORD $0x4e22cc80 // fmla.4s	v0, v4, v2
+	WORD $0x4e23cca1 // fmla.4s	v1, v5, v3
+	WORD $0x91008129 // add	x9, x9, #32
+	WORD $0x9100814a // add	x10, x10, #32
+	WORD $0xf100216b // subs	x11, x11, #8
+	WORD $0x54ffff21 // b.ne	LBB1_5
+	WORD $0x4e20d420 // fadd.4s	v0, v1, v0
+	WORD $0x6e20d400 // faddp.4s	v0, v0, v0
+	WORD $0x7e30d800 // faddp.2s	s0, v0
+	WORD $0xeb03011f // cmp	x8, x3
+	WORD $0x54000140 // b.eq	LBB1_9
+
+BB1_7:
+	WORD $0xcb080069 // sub	x9, x3, x8
+	WORD $0xd37ef50a // lsl	x10, x8, #2
+	WORD $0x8b0a0028 // add	x8, x1, x10
+	WORD $0x8b0a000a // add	x10, x0, x10
+
+BB1_8:
+	WORD $0xbc404541 // ldr	s1, [x10], #4
+	WORD $0xbc404502 // ldr	s2, [x8], #4
+	WORD $0x1f010040 // fmadd	s0, s2, s1, s0
+	WORD $0xf1000529 // subs	x9, x9, #1
+	WORD $0x54ffff81 // b.ne	LBB1_8
+
+BB1_9:
+	WORD $0x1e22c000 // fcvt	d0, s0
+	WORD $0xfd000040 // str	d0, [x2]
+	WORD $0xa8c17bfd // ldp	x29, x30, [sp], #16             ; 16-byte Folded Reload
+	WORD $0xd65f03c0 // ret

--- a/internal/cosine/simd/cosine_avx.go
+++ b/internal/cosine/simd/cosine_avx.go
@@ -7,3 +7,6 @@ import "unsafe"
 
 //go:noescape,nosplit
 func f32_cosine_distance(x unsafe.Pointer, y unsafe.Pointer, result unsafe.Pointer, size uint64)
+
+//go:noescape,nosplit
+func f32_dot_product(x unsafe.Pointer, y unsafe.Pointer, result unsafe.Pointer, size uint64)

--- a/internal/cosine/simd/cosine_neon.go
+++ b/internal/cosine/simd/cosine_neon.go
@@ -7,3 +7,6 @@ import "unsafe"
 
 //go:noescape,nosplit
 func f32_cosine_distance(x unsafe.Pointer, y unsafe.Pointer, result unsafe.Pointer, size uint64)
+
+//go:noescape,nosplit
+func f32_dot_product(x unsafe.Pointer, y unsafe.Pointer, result unsafe.Pointer, size uint64)

--- a/internal/cosine/simd/cosine_neon.s
+++ b/internal/cosine/simd/cosine_neon.s
@@ -114,3 +114,65 @@ LBB0_11:
 	WORD $0xfd000040 // str	d0, [x2]
 	WORD $0xa8c17bfd // ldp	x29, x30, [sp], #16
 	WORD $0xd65f03c0 // ret
+
+TEXT ·f32_dot_product(SB), $0-32
+	MOVD x+0(FP), R0
+	MOVD y+8(FP), R1
+	MOVD result+16(FP), R2
+	MOVD size+24(FP), R3
+	WORD $0xa9bf7bfd       // stp	x29, x30, [sp, #-16]!
+	WORD $0x910003fd       // mov	x29, sp
+	WORD $0xb40000c3       // cbz	x3, .LBB1_3
+	WORD $0xf100207f       // cmp	x3, #8
+	WORD $0x54000102       // b.hs	.LBB1_4
+	WORD $0x2f00e400       // movi	d0, #0000000000000000
+	WORD $0xaa1f03e8       // mov	x8, xzr
+	WORD $0x14000018       // b	.LBB1_7
+
+LBB1_3:
+	WORD $0x2f00e400 // movi	d0, #0000000000000000
+	WORD $0xfd000040 // str	d0, [x2]
+	WORD $0xa8c17bfd // ldp	x29, x30, [sp], #16
+	WORD $0xd65f03c0 // ret
+
+LBB1_4:
+	WORD $0x927df068 // and	x8, x3, #0xfffffffffffffff8
+	WORD $0x91004009 // add	x9, x0, #16
+	WORD $0x6f00e400 // movi	v0.2d, #0000000000000000
+	WORD $0x9100402a // add	x10, x1, #16
+	WORD $0x6f00e401 // movi	v1.2d, #0000000000000000
+	WORD $0xaa0803eb // mov	x11, x8
+
+LBB1_5:
+	WORD $0xad7f8d22 // ldp	q2, q3, [x9, #-16]
+	WORD $0x91008129 // add	x9, x9, #32
+	WORD $0xf100216b // subs	x11, x11, #8
+	WORD $0xad7f9544 // ldp	q4, q5, [x10, #-16]
+	WORD $0x9100814a // add	x10, x10, #32
+	WORD $0x4e22cc80 // fmla	v0.4s, v4.4s, v2.4s
+	WORD $0x4e23cca1 // fmla	v1.4s, v5.4s, v3.4s
+	WORD $0x54ffff21 // b.ne	.LBB1_5
+	WORD $0x4e20d420 // fadd	v0.4s, v1.4s, v0.4s
+	WORD $0xeb03011f // cmp	x8, x3
+	WORD $0x6e20d400 // faddp	v0.4s, v0.4s, v0.4s
+	WORD $0x7e30d800 // faddp	s0, v0.2s
+	WORD $0x54000140 // b.eq	.LBB1_9
+
+LBB1_7:
+	WORD $0xd37ef50a // lsl	x10, x8, #2
+	WORD $0xcb080069 // sub	x9, x3, x8
+	WORD $0x8b0a0028 // add	x8, x1, x10
+	WORD $0x8b0a000a // add	x10, x0, x10
+
+LBB1_8:
+	WORD $0xbc404541 // ldr	s1, [x10], #4
+	WORD $0xbc404502 // ldr	s2, [x8], #4
+	WORD $0xf1000529 // subs	x9, x9, #1
+	WORD $0x1f010040 // fmadd	s0, s2, s1, s0
+	WORD $0x54ffff81 // b.ne	.LBB1_8
+
+LBB1_9:
+	WORD $0x1e22c000 // fcvt	d0, s0
+	WORD $0xfd000040 // str	d0, [x2]
+	WORD $0xa8c17bfd // ldp	x29, x30, [sp], #16
+	WORD $0xd65f03c0 // ret

--- a/internal/cosine/simd/cosine_stub.go
+++ b/internal/cosine/simd/cosine_stub.go
@@ -4,7 +4,10 @@ package simd
 
 import "unsafe"
 
-// stub
 func f32_cosine_distance(x unsafe.Pointer, y unsafe.Pointer, result unsafe.Pointer, size uint64) {
+	panic("not implemented")
+}
+
+func f32_dot_product(x unsafe.Pointer, y unsafe.Pointer, result unsafe.Pointer, size uint64) {
 	panic("not implemented")
 }

--- a/internal/cosine/simd/simd.go
+++ b/internal/cosine/simd/simd.go
@@ -25,12 +25,26 @@ func Cosine(dst *float64, a, b []float32) {
 	case hardware:
 		f32_cosine_distance(unsafe.Pointer(&a[0]), unsafe.Pointer(&b[0]), unsafe.Pointer(dst), uint64(len(a)))
 	default:
-		*dst = cosine(a, b)
+		*dst = genericCosine(a, b)
 	}
 }
 
-// cosine calculates the cosine similarity between two vectors
-func cosine(x, y []float32) float64 {
+// DotProduct calculates the dot product between two vectors and stores the result in the destination
+func DotProduct(dst *float64, a, b []float32) {
+	if len(a) != len(b) {
+		panic("vectors must be of same length")
+	}
+
+	switch {
+	case hardware:
+		f32_dot_product(unsafe.Pointer(&a[0]), unsafe.Pointer(&b[0]), unsafe.Pointer(dst), uint64(len(a)))
+	default:
+		*dst = genericDotProduct(a, b)
+	}
+}
+
+// genericCosine calculates the genericCosine similarity between two vectors
+func genericCosine(x, y []float32) float64 {
 	var sum_xy, sum_xx, sum_yy float64
 	for i := range x {
 		sum_xy += float64(x[i] * y[i])
@@ -44,4 +58,12 @@ func cosine(x, y []float32) float64 {
 	}
 
 	return sum_xy / denominator
+}
+
+func genericDotProduct(a, b []float32) float64 {
+	var sum float64
+	for i := range a {
+		sum += float64(a[i] * b[i])
+	}
+	return sum
 }

--- a/internal/cosine/simd/simd_test.go
+++ b/internal/cosine/simd/simd_test.go
@@ -9,25 +9,42 @@ import (
 
 /*
 cpu: 13th Gen Intel(R) Core(TM) i7-13700K
-BenchmarkCosine/std-24         	14911036	        80.46 ns/op	       0 B/op	       0 allocs/op
-BenchmarkCosine/our-24         	61780514	        18.11 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSIMD/cos-std-24         	14839326	        81.02 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSIMD/cos-acc-24         	66064378	        18.21 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSIMD/dot-std-24         	14868597	        81.11 ns/op	       0 B/op	       0 allocs/op
+BenchmarkSIMD/dot-acc-24         	125554860	         9.564 ns/op	       0 B/op	       0 allocs/op
 */
-func BenchmarkCosine(b *testing.B) {
+func BenchmarkSIMD(b *testing.B) {
 	x := randVec()
 	y := randVec()
 
-	b.Run("std", func(b *testing.B) {
+	b.Run("cos-std", func(b *testing.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			cosine(x, y)
+			genericCosine(x, y)
 		}
 	})
 
-	b.Run("our", func(b *testing.B) {
+	b.Run("cos-acc", func(b *testing.B) {
 		var out float64
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			Cosine(&out, x, y)
+		}
+	})
+
+	b.Run("dot-std", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			genericDotProduct(x, y)
+		}
+	})
+
+	b.Run("dot-acc", func(b *testing.B) {
+		var out float64
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			DotProduct(&out, x, y)
 		}
 	})
 }
@@ -39,8 +56,20 @@ func TestCosine(t *testing.T) {
 
 		var actual float64
 		Cosine(&actual, x, y)
-		expect := cosine(x, y)
-		assert.InDelta(t, expect, actual, 1e-4, "expected %v, got %v", cosine(x, y), actual)
+		expect := genericCosine(x, y)
+		assert.InDelta(t, expect, actual, 1e-4, "expected %v, got %v", genericCosine(x, y), actual)
+	}
+}
+
+func TestDotProduct(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		x := randVec()
+		y := randVec()
+
+		var actual float64
+		DotProduct(&actual, x, y)
+		expect := genericDotProduct(x, y)
+		assert.InDelta(t, expect, actual, 1e-4, "expected %v, got %v", expect, actual)
 	}
 }
 


### PR DESCRIPTION
This pull request introduces several optimizations and enhancements to the vector similarity calculations. The most important changes include adding a new dot product function, normalizing vectors before calculations, and updating benchmarks and tests to reflect these changes.

### Optimizations and Enhancements:

* [`internal/cosine/simd/simd.go`](diffhunk://#diff-348d2ee4e694745d8f1a75c598812b521085f62262b474ba20889bd9a57d1228L28-R47): Introduced the `DotProduct` function to calculate the dot product between two vectors, added `genericDotProduct` for non-hardware implementations, and updated the `Cosine` function to use `genericCosine` for non-hardware cases. [[1]](diffhunk://#diff-348d2ee4e694745d8f1a75c598812b521085f62262b474ba20889bd9a57d1228L28-R47) [[2]](diffhunk://#diff-348d2ee4e694745d8f1a75c598812b521085f62262b474ba20889bd9a57d1228R62-R69)

* [`bruteforce.go`](diffhunk://#diff-4b04580a8fbf2487dd37521a5283a205cbadbe8a9f7da8b881435b983d40934fR40-R41): Added vector normalization in the `Add` and `Search` methods to ensure vectors are unit vectors, allowing the use of dot product for cosine similarity calculations. [[1]](diffhunk://#diff-4b04580a8fbf2487dd37521a5283a205cbadbe8a9f7da8b881435b983d40934fR40-R41) [[2]](diffhunk://#diff-4b04580a8fbf2487dd37521a5283a205cbadbe8a9f7da8b881435b983d40934fR54-R60) [[3]](diffhunk://#diff-4b04580a8fbf2487dd37521a5283a205cbadbe8a9f7da8b881435b983d40934fR82-R96)

### Performance Improvements:

* `internal/cosine/cosine_apple.c`, `internal/cosine/cosine_avx.c`, `internal/cosine/cosine_neon.c`: Added the `f32_dot_product` function to each SIMD implementation to support efficient dot product calculations. [[1]](diffhunk://#diff-4d8750164ac53c935a853e8fa3326a43ded7d0ef3468e99cf92befe51c0ef6e7R30-R40) [[2]](diffhunk://#diff-87057ed73208737571fed8bb29daa7210611105113585f6fd8cab21fbb441622R30-R40) [[3]](diffhunk://#diff-4d8750164ac53c935a853e8fa3326a43ded7d0ef3468e99cf92befe51c0ef6e7R30-R40)

### Benchmark and Test Updates:

* [`internal/cosine/simd/simd_test.go`](diffhunk://#diff-6ee5de1b9e013801dd95536103452d44e557323acc6dd2bbfccc427e2ad42c44L12-R49): Updated benchmarks to include dot product performance and added tests for the new `DotProduct` function. [[1]](diffhunk://#diff-6ee5de1b9e013801dd95536103452d44e557323acc6dd2bbfccc427e2ad42c44L12-R49) [[2]](diffhunk://#diff-6ee5de1b9e013801dd95536103452d44e557323acc6dd2bbfccc427e2ad42c44L42-R72)

### Miscellaneous:

* [`bruteforce_test.go`](diffhunk://#diff-0006296a3b7ac863ab88b8cc379135c1e2acfe9744578bd50a6df6df0df6ef46L16-R16): Updated benchmark results to reflect the performance improvements from using dot product and vector normalization.